### PR TITLE
Use Zig package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,64 @@
 # raygui.zig
 Idiomatic [raygui](https://github.com/raysan5/raygui) **RAYGUIAPI** (raygui.h) bindings for [Zig](https://ziglang.org/) (master).
 
-## usage
+## <a id="usage">usage</a>
+
+Add this as a dependency to your `build.zig.zon`
+```zig
+.{
+    .name = "example",
+    .version = "1.0.0",
+    .paths = ...,
+    .dependencies = .{
+        .raylib_zig = .{
+            .url = "https://github.com/ryupold/raygui.zig/archive/<commit>.tar.gz",
+            .hash = "<hash>",
+        },
+    },
+}
+```
+
+Then add the raygui module to your compile step in your `build.zig`. Note that module has a dependency on [`raygui.zig`](https://github.com/ryupold/raygui.zig), so you should probably configure your compile step with that.
+```zig
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void
+{
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    const compile = ...;
+
+    const raygui_zig = b.dependency("raygui_zig", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    compile.root_module.addImport("raygui", raygui_zig.module("raygui"));
+}
+```
+
+and import in main.zig:
+```zig
+const raylib = @import("raylib");
+const raygui = @import("raygui");
+
+pub fn main() void {
+    raylib.SetConfigFlags(raylib.ConfigFlags{ .FLAG_WINDOW_RESIZABLE = true });
+    raylib.InitWindow(800, 800, "hello world!");
+    raylib.SetTargetFPS(60);
+
+    defer raylib.CloseWindow();
+
+    while (!raylib.WindowShouldClose()) {
+        raylib.BeginDrawing();
+        defer raylib.EndDrawing();
+
+        raylib.ClearBackground(raylib.BLACK);
+        raylib.DrawFPS(10, 10);
+
+        raylib.DrawText("hello world!", 100, 100, 20, raylib.YELLOW);
+    }
+}
+```
 
 The easy way would be adding this as submodule directly in your source folder.
 Thats what I do until there is an official package manager for Zig.

--- a/README.md
+++ b/README.md
@@ -55,58 +55,7 @@ pub fn main() void {
         defer raylib.EndDrawing();
 
         raylib.ClearBackground(raylib.BLACK);
-        raylib.DrawFPS(10, 10);
-
-        raylib.DrawText("hello world!", 100, 100, 20, raylib.YELLOW);
-    }
-}
-```
-
-The easy way would be adding this as submodule directly in your source folder.
-Thats what I do until there is an official package manager for Zig.
-
-```sh
-cd $YOUR_SRC_FOLDER
-git submodule add https://github.com/ryupold/raygui.zig raygui
-git submodule update --init --recursive
-```
-
-The bindings have been prebuilt so you just need to add raylib as module
-
-build.zig:
-```zig
-const raylib = @import("path/to/raylib.zig/build.zig");
-const raygui = @import("path/to/raygui.zig/build.zig");
-
-pub fn build(b: *std.Build) !void {
-    const target = b.standardTargetOptions(.{});
-    const mode = b.standardOptimizeOption(.{});
-    const exe = ...;
-    raylib.addTo(b, exe, target, mode);
-    raygui.addTo(b, exe, target, mode);
-}
-```
-
-and import in main.zig:
-```zig
-const raylib = @import("raylib");
-const raygui = @import("raygui");
-
-pub fn main() void {
-    raylib.InitWindow(800, 800, "hello world!");
-    raylib.SetConfigFlags(.FLAG_WINDOW_RESIZABLE);
-    raylib.SetTargetFPS(60);
-
-    defer raylib.CloseWindow();
-
-    while (!raylib.WindowShouldClose()) {
-        raylib.BeginDrawing();
-        defer raylib.EndDrawing();
-        
-        raylib.ClearBackground(raylib.BLACK);
-        raylib.DrawFPS(10, 10);
-
-        if (raygui.GuiButton(.{ .x = 100, .y = 100, .width = 200, .height = 100 }, "press me!")) {
+        if (raygui.GuiButton(.{ .x = 100, .y = 100, .width = 200, .height = 100 }, "press me!") != 0) {
             std.debug.print("pressed\n", .{});
         }
     }
@@ -115,8 +64,6 @@ pub fn main() void {
 
 > See `build.zig` in [examples-raylib.zig](https://github.com/ryupold/examples-raylib.zig) for how to build.
 
-> Note: you only need the files `raygui.zig`, `raygui_marshal.h` and `raygui_marshal.c` for this to work
-> 
 This weird workaround with `raygui_marshal.h/raygui_marshal.c` I actually had to make for Webassembly builds to work, because passing structs as function parameters or returning them cannot be done on the Zig side somehow. If I try it, I get a runtime error "index out of bounds". This happens only in WebAssembly builds. So `raygui_marshal.c` must be compiled with `emcc`. See [build.zig](https://github.com/ryupold/examples-raylib.zig/blob/main/build.zig) in the examples.
 
 ## custom definitions

--- a/build.zig
+++ b/build.zig
@@ -29,9 +29,10 @@ pub fn build(b: *std.Build) !void {
     });
     module.addIncludePath(.{ .path = "." });
     module.addIncludePath(raygui.path("src"));
+    module.addIncludePath(raylib.path("src"));
     // TODO: relative path doesn't work here when used as a dependency, not sure why...
     const marshal_c_path = try b.build_root.join(b.allocator, &.{"raygui_marshal.c"});
-    module.addCSourceFile(.{ .file = .{.path = marshal_c_path}, .flags = &.{} });
+    module.addCSourceFile(.{ .file = .{.path = marshal_c_path}, .flags = &.{"-DRAYGUI_IMPLEMENTATION"} });
     module.link_libc = true;
     if (target.result.os.tag == .emscripten) {
         if (b.sysroot == null) {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .paths = .{""},
     .dependencies = .{
         .raygui = .{
-            .url = "https://github.com/raysan5/raygui/archive/40f3df5b865eee0cd87a9e4e1347cb04c87841f8.tar.gz",
-            .hash = "12209bb07b3926d027de330c05d9425eaa52cc1a40eed291628370ba759653d5f961",
+            .url = "https://github.com/raysan5/raygui/archive/45e7f967e62088b9fec02ac38c07d4b67d6466b0.tar.gz",
+            .hash = "1220bfb199fc2560ca902f0fdd658f79e673ead9760ade508c1e871f0f169a1c7e66",
         },
         .raylib_zig = .{
             .url = "https://github.com/kapricorn-media/raylib.zig/archive/f7d7ca14a086b4866e0b37013da4d18ab2d4af59.tar.gz",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,15 @@
+.{
+    .name = "raygui.zig",
+    .version = "0.0.0",
+    .paths = .{""},
+    .dependencies = .{
+        .raygui = .{
+            .url = "https://github.com/raysan5/raygui/archive/40f3df5b865eee0cd87a9e4e1347cb04c87841f8.tar.gz",
+            .hash = "12209bb07b3926d027de330c05d9425eaa52cc1a40eed291628370ba759653d5f961",
+        },
+        .raylib_zig = .{
+            .url = "https://github.com/kapricorn-media/raylib.zig/archive/f7d7ca14a086b4866e0b37013da4d18ab2d4af59.tar.gz",
+            .hash = "12206c13730136f11e9811ed4a0d135eb66cbd0e20ca3e872016993b002d956ad55a",
+        },
+    },
+}


### PR DESCRIPTION
Sister PR to https://github.com/ryupold/raylib.zig/pull/38. This one is much simpler because all the emscripten heavy lifting is handled by `raylib.zig`. All that's needed to include `raygui.zig` into your project is to add the dependency, and then add the module to your compile target (assuming `raylib.zig` has already been set up for it).

**1 problem**: Because this repo is referencing its own version of `raylib.zig`, it can cause a duplicate symbol error if its version doesn't match the one from the upstream repo using it... hmmm